### PR TITLE
[BB-4060] Add `pluggable_override` for `create_xblock_info`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,20 +6,43 @@ Change Log
    in this file.  It adheres to the structure of http://keepachangelog.com/ ,
    but in reStructuredText instead of Markdown (for ease of incorporation into
    Sphinx documentation and the PyPI description).
-   
+
    This project adheres to Semantic Versioning (http://semver.org/).
 
 .. There should always be an "Unreleased" section for changes pending release.
 
-Unreleased
-~~~~~~~~~~
-
-*
-
-[0.1.0] - 2019-08-23
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[0.4.0] - 2021-04-13
+~~~~~~~~~~~~~~~~~~~~
 
 Added
 _____
 
-* First release on PyPI.
+* An override for ``create_xblock_info``.
+
+
+[0.3.0] - 2021-04-07
+~~~~~~~~~~~~~~~~~~~~
+
+Changed
+_______
+
+* Initial working version for the upstreamed ``pluggable_override``. Passes args explicitly instead of relying on an implicit behavior.
+
+
+[0.2.0] - 2020-09-18
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+_____
+
+* ``IconOverrideMixin``, with an ``icon_override`` XBlock field.
+
+
+
+[0.1.0] - 2019-08-23
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+_____
+
+* First version, compatible with a WIP approach.

--- a/README.rst
+++ b/README.rst
@@ -26,13 +26,13 @@ On Open edX Devstack:
         pip install -e /edx/src/custom-unit-icons/
         logout
 
-#. Set the following variables in either:
+#. Set the following variables for the LMS, in either:
 
     a. ``/edx/etc/lms.yml``:
 
         .. code-block:: yaml
 
-            GET_UNIT_ICON_IMPL: custom_unit_icons.icons.get_icon
+            OVERRIDE_GET_UNIT_ICON: custom_unit_icons.icons.get_icon
             XBLOCK_EXTRA_MIXINS:
                 - custom_unit_icons.icons.IconOverrideMixin
 
@@ -41,7 +41,25 @@ On Open edX Devstack:
         .. code-block:: python
 
             from .common import XBLOCK_MIXINS
-            GET_UNIT_ICON_IMPL = 'custom_unit_icons.icons.get_icon'
+            OVERRIDE_GET_UNIT_ICON = 'custom_unit_icons.icons.get_icon'
+            XBLOCK_MIXINS += ('custom_unit_icons.icons.IconOverrideMixin',)
+
+#. Set the following variables for the Studio, in either:
+
+    a. ``/edx/etc/studio.yml``:
+
+        .. code-block:: yaml
+
+            OVERRIDE_CREATE_XBLOCK_INFO: custom_unit_icons.icons.create_xblock_info
+            XBLOCK_EXTRA_MIXINS:
+                - custom_unit_icons.icons.IconOverrideMixin
+
+    #. ``cms/envs/private.py``:
+
+        .. code-block:: python
+
+            from .common import XBLOCK_MIXINS
+            OVERRIDE_CREATE_XBLOCK_INFO = 'custom_unit_icons.icons.create_xblock_info'
             XBLOCK_MIXINS += ('custom_unit_icons.icons.IconOverrideMixin',)
 
 #. Restart LMS:

--- a/custom_unit_icons/__init__.py
+++ b/custom_unit_icons/__init__.py
@@ -2,6 +2,6 @@
 This plugin allows customizing unit icons in Studio..
 """
 
-__version__ = '0.3.0'
+__version__ = '0.4.0'
 
 default_app_config = 'custom_unit_icons.apps.CustomUnitIconsConfig'  # pylint: disable=invalid-name

--- a/custom_unit_icons/icons.py
+++ b/custom_unit_icons/icons.py
@@ -18,7 +18,6 @@ class IconOverrideMixin:
         scope=Scope.settings,
     )
 
-
 def get_icon(prev_fn, unit):
     """
     Get icon specified in modulestore.
@@ -28,3 +27,12 @@ def get_icon(prev_fn, unit):
     if icon == 'default':
         return prev_fn(unit)
     return icon
+
+def create_xblock_info(prev_fn, xblock, *args, **kwargs):
+    """
+    Get icon specified in modulestore.
+    If `default` is specified there, make a fallback to the default implementation.
+    """
+    xblock_info = prev_fn(xblock, *args, **kwargs)
+    xblock_info['icon'] = xblock.icon_override
+    return xblock_info


### PR DESCRIPTION
**Description:**
This overrides XBlock fields that are being passed to the Studio to include the custom `icon` field. Without this, the Studio is not able to determine the icon which is currently being used.

**JIRA:** [BB-4060](https://tasks.opencraft.com/browse/BB-4060)

**Dependencies:**
This requires a PR, which is currently private. The public PR will be linked here once it's opened.

**Merge deadline:** Before the end of the sprint.

**Installation instructions:** See the private MR.

**Testing instructions:** See the private MR.

**Reviewers:**
- [x] @0x29a 

**Merge checklist:**
- [x] All reviewers approved
- [x] <s>CI build is green</s>
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [x] Create a tag
- [x] <s>Check new version is pushed to PyPI after tag-triggered build is finished.</s>
- [x] Delete working branch (if not needed anymore)

**Author concerns:** Let's merge the upstream PR before this.