### PR TITLE
[BB-4164] Support legacy icon overrides

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,14 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[0.5.0] - 2021-05-10
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+_____
+
+* Support for the legacy icon overrides.
+
 [0.4.0] - 2021-04-13
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/custom_unit_icons/__init__.py
+++ b/custom_unit_icons/__init__.py
@@ -2,6 +2,6 @@
 This plugin allows customizing unit icons in Studio..
 """
 
-__version__ = '0.4.0'
+__version__ = '0.5.0'
 
 default_app_config = 'custom_unit_icons.apps.CustomUnitIconsConfig'  # pylint: disable=invalid-name

--- a/custom_unit_icons/icons.py
+++ b/custom_unit_icons/icons.py
@@ -1,4 +1,4 @@
-from xblock.fields import String, Scope
+from xblock.fields import Integer, String, Scope
 
 # Make '_' a no-op so we can scrape strings
 # Using lambda instead of `django.utils.translation.ugettext_noop` because Django cannot be imported in this file
@@ -6,7 +6,7 @@ _ = lambda text: text
 
 
 class IconOverrideMixin:
-    """ Allow changing the icon used for this specific instance of this XBlock """
+    """Allow changing the icon used for this specific instance of this XBlock"""
 
     def __init__(self):
         pass
@@ -18,21 +18,53 @@ class IconOverrideMixin:
         scope=Scope.settings,
     )
 
+    # DEPRECATED: We have been using the `icon` field in the modulestore before introducing the `icon_override` one.
+    #  The `icon` field and the `ICON_MAPPING` list are used by the existing courses, which have been created the
+    #  "old" way. These were introduced for keeping the backward compatibility and should be treated as read-only.
+    icon = Integer(
+        display_name=_("Deprecated Icon Override"),
+        default=0,
+        help=_("Deprecated XBlock Icon Override ID"),
+        scope=Scope.settings,
+    )
+
+    ICON_MAPPING = [
+        icon_override.default,
+        'text',
+        'video',
+        'interactive',
+        'downloadable',
+        'ask-question',
+        'assess-question',
+        'text-box',
+    ]
+
+
 def get_icon(prev_fn, unit):
     """
-    Get icon specified in modulestore.
-    If `default` is specified there, make a fallback to the default implementation.
+    Get icon specified in the modulestore.
+
+    If a default value is specified there, make a fallback to a default implementation.
     """
-    icon = getattr(unit, 'icon_override', 'default')
-    if icon == 'default':
+    icon = getattr(unit, 'icon_override', IconOverrideMixin.icon_override.default)
+
+    # DEPRECATED: This check is here for supporting the deprecated `icon` field.
+    if icon == IconOverrideMixin.icon_override.default:
+        icon_id = getattr(unit, 'icon', 0)
+        if icon_id >= len(IconOverrideMixin.ICON_MAPPING):
+            icon_id = 0
+        icon = IconOverrideMixin.ICON_MAPPING[icon_id]
+
+    if icon == IconOverrideMixin.icon_override.default:
         return prev_fn(unit)
     return icon
 
+
 def create_xblock_info(prev_fn, xblock, *args, **kwargs):
     """
-    Get icon specified in modulestore.
-    If `default` is specified there, make a fallback to the default implementation.
+    Create the information needed for client-side XBlockInfo with the original implementation and add an icon
+    field there, so it can be retrieved in the Studio.
     """
     xblock_info = prev_fn(xblock, *args, **kwargs)
-    xblock_info['icon'] = xblock.icon_override
+    xblock_info['icon'] = get_icon(lambda _: IconOverrideMixin.icon_override.default, xblock)
     return xblock_info


### PR DESCRIPTION
**Description:** We have been using the integer `icon` field in the modulestore before introducing the `icon_override` one. This adds support for these "old" overrides.

**JIRA:** [BB-4164](https://tasks.opencraft.com/browse/BB-4164)
**Dependencies:**  custom theme

**Merge deadline:** Current sprint

**Installation instructions:** List any non-trivial installation 
instructions.

**Testing instructions:**
1. Add the following to `lms/envs/private.py`:
   ```python
   from .common import XBLOCK_MIXINS
   OVERRIDE_GET_UNIT_ICON = 'custom_unit_icons.icons.get_icon'
   XBLOCK_MIXINS += ('custom_unit_icons.icons.IconOverrideMixin',)
   ```
1. Add the following to `cms/envs/private.py`:
   ```python
   from .common import XBLOCK_MIXINS
   OVERRIDE_CREATE_XBLOCK_INFO = 'custom_unit_icons.icons.create_xblock_info'
   OVERRIDE_GET_UNIT_ICON = 'custom_unit_icons.icons.get_icon'
   XBLOCK_MIXINS += ('custom_unit_icons.icons.IconOverrideMixin',)
   ```
1. Install this and set up the comprehensive theme.
1. Restart LMS and Studio.
1. Run the following snippet:
    ```python
    from xmodule.modulestore.django import modulestore
    from opaque_keys.edx.keys import UsageKey
    
    usage_key = UsageKey.from_string('block-v1:edX+DemoX+Demo_Course+type@vertical+block@867dddb6f55d410caaa9c1eb9c6743ec')
    item = modulestore().get_item(usage_key)
    item.icon = 2
    modulestore().update_item(item, 1)
    ```
1. Go to [this page](http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/courseware/interactive_demonstrations/19a30717eff543078a5d94ae9d6c18a5/?child=first) and see that the first unit icon is `fa seq_video`.
1. Go to the Course Outline page [in Studio](http://localhost:18010/course/course-v1:edX+DemoX+Demo_Course) and see that this unit (`Course > Example Week 1: Getting Started > Lesson 1 - Getting Started > Getting Started`) has the custom icon set to "Video".
1. Set the icon back to "Default" and see that it has been restored.

**Reviewers:**
- [x] @0x29a 

**Merge checklist:**
- [ ] All reviewers approved
- [x] CI build is green: n/a
- [x] Version bumped
- [x] Changelog record added
- [x] Documentation updated (not only docstrings): n/a
- [x] Commits are squashed

**Post merge:**
- [x] Create a tag
- [x] Check new version is pushed to PyPI after tag-triggered build is 
      finished: n/a
- [x] Delete working branch (if not needed anymore)

**Author concerns:** List any concerns about this PR - inelegant 
solutions, hacks, quick-and-dirty implementations, concerns about 
migrations, etc.
